### PR TITLE
fix: missing xmlns:u for Ursa.Controls on AOOH_Gallery

### DIFF
--- a/Src/Example/AOOH_Gallery/Views/MainView.axaml
+++ b/Src/Example/AOOH_Gallery/Views/MainView.axaml
@@ -1,4 +1,5 @@
-﻿<u:UrsaView xmlns="https://github.com/avaloniaui"
+<u:UrsaView xmlns="https://github.com/avaloniaui"
+             xmlns:u="clr-namespace:Ursa.Controls;assembly=AOOH_Gallery"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"


### PR DESCRIPTION
when we build the project, find the error, and try to fix for this issue~

![95c59dcdbced9178a34524b7149cafe3](https://github.com/user-attachments/assets/2d776dca-199f-46d7-800d-e7d09eba01fb)
